### PR TITLE
Disable Boost float128 support on Linux

### DIFF
--- a/recipes/libradolan/build.sh
+++ b/recipes/libradolan/build.sh
@@ -17,7 +17,7 @@ then
     # for Linux
     export CC=gcc
     export CXX=g++
-    export CXXFLAGS="${CXXFLAGS}"
+    export CXXFLAGS="${CXXFLAGS} -DBOOST_MATH_DISABLE_FLOAT128"
     export LDFLAGS="${LDFLAGS}"
     export LINKFLAGS="${LDFLAGS}"
 else

--- a/recipes/libradolan/build.sh
+++ b/recipes/libradolan/build.sh
@@ -8,7 +8,7 @@ then
     export MACOSX_VERSION_MIN="10.7"
     export MACOSX_DEPLOYMENT_TARGET="${MACOSX_VERSION_MIN}"
     export CXXFLAGS="${CXXFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
-    export CXXFLAGS="${CXXFLAGS} -stdlib=libc++"
+    export CXXFLAGS="${CXXFLAGS} -stdlib=libc++ -std=c++11"
     export LDFLAGS="${LDFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
     export LDFLAGS="${LDFLAGS} -stdlib=libc++ -lc++"
     export LINKFLAGS="${LDFLAGS}"

--- a/recipes/libradolan/yum_requirements.txt
+++ b/recipes/libradolan/yum_requirements.txt
@@ -1,1 +1,0 @@
-devtoolset-2-libquadmath-devel


### PR DESCRIPTION
Tacks on the needed commit to this PR ( https://github.com/conda-forge/staged-recipes/pull/591 ) to disable Boost float128 bit support and let this build smoothly. Inspired by this ticket ( https://svn.boost.org/trac/boost/ticket/9240 ), which added the feature. To see this change in action, look at this PR ( https://github.com/conda-forge/thrift-cpp-feedstock/pull/3 ).

Also, enabling C++11 support helped here. Not sure whether `libradolan` use C++0x or C++11 features. In any event, our Boost is compiled with them so this can be useful in cases like this. By making that change, but run into a different error involving `_Bool` being undefined. Snippet from the traceback below.

```
<scratch space>:303:1: note: expanded from here
"/zopt/conda2/envs/_build/include/ncEnumType.h"
^
In file included from /zopt/conda2/conda-bld/work/radolan-c8f40f7cd6ecc4050e7cf7394e64e7366d99ce16/src/classes/netcdf_converter.cpp:28:
In file included from /zopt/conda2/conda-bld/work/radolan-c8f40f7cd6ecc4050e7cf7394e64e7366d99ce16/include/radolan/netcdf_converter.h:29:
In file included from /zopt/conda2/conda-bld/work/radolan-c8f40f7cd6ecc4050e7cf7394e64e7366d99ce16/include/radolan/radolan.h:32:
/zopt/conda2/conda-bld/work/radolan-c8f40f7cd6ecc4050e7cf7394e64e7366d99ce16/include/radolan/read.h:64:52: error: unknown type name '_Bool'
int RDReadScan(const char *filename, RDScan *scan, _Bool ommitOutside);
```